### PR TITLE
Fix failing tests

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -141,7 +141,7 @@ class Client implements ClientInterface
 	private function request($host, $path, $data)
 	{
 		return $this->guzzleClient->post(
-			sprintf( 'https://%s/%s', $host, $path ),
+			sprintf( $this->proxyApiUrl ?: 'https://%s%s', $host, $path ),
 			[
 				'headers' => [
 					'Authorization' => sprintf('key=%s', $this->apiKey),

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -29,7 +29,10 @@ class ClientTest extends PhpFcmTestCase
         $guzzle = \Mockery::mock(\GuzzleHttp\Client::class);
         $guzzle->shouldReceive('post')
             ->once()
-            ->with(Client::DEFAULT_API_URL, array('headers' => $headers, 'body' => '{"to":"\\/topics\\/test","priority":"high"}'))
+            ->with(Client::DEFAULT_API_URL, ['headers' => $headers, 'body' => json_encode([
+                'to' => '/topics/test',
+                'priority' => 'high'
+            ])])
             ->andReturn(\Mockery::mock(Response::class));
 
         $this->fixture->injectHttpClient($guzzle);


### PR DESCRIPTION
1. remove trailing slash in host and path combination
2. Use proxy URL if available